### PR TITLE
updates to installation instructions

### DIFF
--- a/docs/_sources/installation.rst.txt
+++ b/docs/_sources/installation.rst.txt
@@ -2,9 +2,7 @@
 Installing agweather-qaqc
 #########################
 
-The package agweatherqaqc includes an environment.yml file for easy installation. The file is located at: **"/agweatherqaqc/env/environment.yml"**
-
-The rest of this page is written for a generalist audience.
+This page is written for a generalist audience.
 
 Anaconda
 ========
@@ -12,27 +10,41 @@ Anaconda is a free and open-source distribution of Python that, in exchange for 
 
 Visit the `Anaconda website <https://www.anaconda.com/download/>`_ to download the correct Anaconda version (agweather-qaqc requires a version >= 3.9) for your operating system, and then follow the prompts to install it.
 
-Once you're done installing Anaconda, open the Anaconda prompt and type::
+Once you're done installing Anaconda, open the Anaconda prompt (on Windows) or Terminal (on MacOS or Linux) and type::
 
     >conda info
 
 You should see some text regarding the version of Anaconda you've installed. If you get an error, you may have made a mistake during the installation.
 
+Cloning the Repository
+======================
+
+You can get the latest version of agweather-qaqc by cloning its `Github Repository <https://github.com/WSWUP/agweather-qaqc>`_ or by `clicking here. <https://github.com/WSWUP/agweather-qaqc/archive/master.zip>`_
+
+    >git clone https://github.com/WSWUP/agweather-qaqc
+
+And then change into the repository root directory
+
+    >cd agweatherqaqc
+
+
 Setting up the Environment
 ==========================
 
-Using the Anaconda prompt, navigate to the environment.yml file found at **"/agweatherqaqc/env/environment.yml"**, and then type::
+The package agweatherqaqc includes an environment.yml file for easy installation. The file is located at: **"agweatherqaqc/env/environment.yml"**
 
-    >conda env create -f environment.yml
+To set up the conda environment, type::
 
-And then follow the prompts. This will setup a new environment called **"agweatherqaqc"**, which can be activated by typing::
+    >conda env create -f agweatherqaqc/env/environment.yml
 
-    >activate agweatherqaqc
+Then follow the prompts to setup a new environment called **"agweatherqaqc"**::
 
-After this, setup is complete. Once your `input files are configured <data_preparation.html>`_ agweather-qaqc is ready to run.
+    >conda activate agweatherqaqc
+
+After this, setup is complete. The next step is to configure input files.
 
 .. note::
-   You will have to activate your environment whenever you close the Anaconda prompt.
+   You will have to reactivate your environment whenever you open a new Anaconda prompt or Terminal.
 
 Running the agweather-qaqc
 ==========================
@@ -41,7 +53,6 @@ This package is run locally, so the directory can be placed wherever you want it
 
 You will run the code by directing the Anaconda prompt to the location of the file **qaqc_single_station.py** and running it from there.
 
-You can get the latest version of agweather-qaqc by cloning its `Github Repository <https://github.com/WSWUP/agweather-qaqc>`_ or by `clicking here. <https://github.com/WSWUP/agweather-qaqc/archive/master.zip>`_
 
 
 


### PR DESCRIPTION
While reviewing for JOSS https://github.com/openjournals/joss-reviews/issues/6368 

I wrote up some suggestions for making the setup instructions more clear, and implemented some of the suggestions in this Pull Request.

Below are the associated notes providing some rationale for the changes here:

---

The documentation could be improved for end users. And should be reviewed and re-written making sure that they work easily on all supported platforms. For example, ‘Anaconda prompt’ is only available on Windows. The equivalent on MacOS and Linux is a terminal with appropriate modifications to bashrc or zshrc made during the Anaconda installation.

The statement ‘this page is written for a generalist audience’ should be given context (why include this?) … is it because experts should feel free to skip Anaconda, but instructions for doing so are not included?

Installation instructions assume that the code is available on the computer. They should include the commands required e.g. git clone or conda install

When referring to repository root, don’t use a leading “/“ which implies the location is relative to the system root directory. i.e.  “agweatherqaqc/env/environment.yml” instead of “/agweatherqaqc/env/environment.yml” 

Here are some other places where users might get stuck:
 “Once you’re done installing Anaconda, open the Anaconda prompt and type: condo info”
- On macOS and Linux there is no anaconda prompt, just a terminal
- Should be “open the Anaconda prompt (on Windows) or Terminal (MacOS or Linux)”

“Using the Anaconda prompt, navigate to the environment.yml file”
- Again, the concept of anaconda prompt is specific to windows
- Steps used to ‘Navigate to’  should be given (e.g. `git clone … `; `cd agweatherqaqc/env`; `condo env …`)
- But, rather than navigate to, perhaps simpler to navigate to repository root and specify path in condo env command, e.g.  `conda env create -f agweatherqaqc/env/environment.yml`

 “And then follow the prompts. This will setup a new environment called “agweatherqaqc”, which can be activated by typing:
>activate agweatherqaqc”
- There is no command ‘activate’, perhaps only on the anaconda prompt? On MacOS it is ‘conda activate’
- If by ‘follow the prompts’ you mean ‘conda activate’, you can just say ‘activate the conda environment using `conda activate agweatherqaqc` as instructed 

Ultimately, the following commands or their equivalent should be provided in order to ensure users have all of the information required for setup:   

```
git clone git@github.com:WSWUP/agweather-qaqc.git
cd agweather-qaqc
conda env create -f agweatherqaqc/env/environment.yml 
conda activate agweatherqaqc
```

Remove “After this, setup is complete. Once your [input files are configured](https://wswup.github.io/agweather-qaqc/data_preparation.html) agweather-qaqc is ready to run.” Since it is covered in the next section. 